### PR TITLE
Mastercard API version upgraded to 81.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.3.6] - 2024-08-06
+### Enhancement
+- Mastercard API version upgraded to 81.
+- Module is now compatible with Magento version 2.4.6 p6.
+- Implemented a notification feature to alert the admin whenever a new version is launched on GitHub/Marketplace.
+### Changed
+- Hosted Session – The VATO option will only be supported when 3DS is disabled.
+-  ACH will not support the VATO payment option as it does not allow capturing the amount.
+
 ## [2.3.5] - 2024-02-02
 ### Enhancement
 - Mastercard API version upgraded to 73.

--- a/Gateway/Command/VerificationStrategyCommand.php
+++ b/Gateway/Command/VerificationStrategyCommand.php
@@ -34,6 +34,7 @@ class VerificationStrategyCommand implements CommandInterface
     const PROCESS_3DS_RESULT = '3ds_process';
     const CREATE_TOKEN = 'create_token';
     const CREATE_ORDER_TOKEN = 'tokenize';
+    const METHOD_VERIFY = 'order';
 
     /**
      * @var Command\CommandPoolInterface
@@ -81,6 +82,13 @@ class VerificationStrategyCommand implements CommandInterface
     {
         /** @var Payment $paymentInfo */
         $paymentInfo = $paymentDO->getPayment();
+        
+        $payment_action = $this->config->getValue('payment_action');
+        
+        //Don't use 3DS for verify payment action
+        if($payment_action == static::METHOD_VERIFY){
+             return false;
+         }
 
         // Don't use 3DS in admin
         if ($this->state->getAreaCode() === Area::AREA_ADMINHTML) {

--- a/Model/Adminhtml/Source/Ach/MappedPaymentAction.php
+++ b/Model/Adminhtml/Source/Ach/MappedPaymentAction.php
@@ -32,10 +32,10 @@ class MappedPaymentAction extends BasicPaymentAction
                 'value' => MethodInterface::MAPPED_ACTION_ORDER_PAY,
                 'label' => __('Pay'),
             ],
-            [
+          /*  [
                 'value' => MethodInterface::MAPPED_ACTION_ORDER_VERIFY,
                 'label' => __('Verify and Add Token to Order'),
-            ],
+            ], */
         ];
     }
 }

--- a/Model/System/Message/ReleaseNotification.php
+++ b/Model/System/Message/ReleaseNotification.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Copyright (c) 2016-2024 Mastercard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Mastercard\Mastercard\Model\System\Message;
+
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\ValidatorException;
+use Magento\Framework\Notification\MessageInterface;
+use Magento\Framework\Phrase;
+use Magento\Backend\Model\Session;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
+use Magento\Framework\Filesystem\Directory\ReadFactory;
+use Magento\Framework\Serialize\Serializer\Json;
+
+/**
+ * Class ReleaseNotification
+ *
+ * @package Mastercard\Mastercard\Model\System\Message
+ */
+class ReleaseNotification implements MessageInterface {
+
+    /**
+     * ReleaseNotification constructor.
+     *
+     * @param Session $session
+     * @param Curl $curl
+     * @param ComponentRegistrarInterface $componentRegistrar
+     * @param ReadFactory $readFactory
+     */
+    public function __construct(
+        private Session $session,
+        private Curl $curl,
+        private ComponentRegistrarInterface $componentRegistrar,
+        private ReadFactory $readFactory,
+        private Json $json
+    ){}
+
+    /**
+     * Message identity
+     */
+    const MESSAGE_IDENTITY = 'release_notification';
+
+    /**
+     * API Endpoint for checking latest github release
+     */
+    const API_ENDPOINT = 'https://api.github.com/repos/fingent-corp/module-mastercard/releases/latest';
+
+    /**
+     * Get MPGS Module name
+     */
+    const MODULE_FULL_NAME = 'Mastercard_Mastercard';
+
+    /**
+     * Release notes url
+     */
+    const RELEASE_NOTES_URL = 'https://mpgs.fingent.wiki/target/magento-2-mastercard-payment-gateway-services/release-notes/';
+
+    /**
+     * Retrieve unique system message identity
+     *
+     * @return string
+     */
+    public function getIdentity():string
+    {
+        return self::MESSAGE_IDENTITY;
+    }
+
+    /**
+     * Check whether the release notification should be shown
+     *
+     * @return bool
+     */
+    public function isDisplayed():bool
+    {
+        try {
+            return $this->checkIfNewReleaseAvailable();
+        } catch (FileSystemException $e) {
+            throw new LocalizedException(__('Something went wrong while checking the MPGS release information.'));
+        } catch (ValidatorException $e) {
+            throw new LocalizedException(__('Something went wrong while checking the MPGS version information.'));
+        }
+    }
+
+    /**
+     * Retrieve message content
+     *
+     * @return Phrase
+     * @throws FileSystemException
+     * @throws ValidatorException
+     */
+    public function getText()
+    {
+        return __(sprintf('A new version (%s) of the Mastercard payment gateway plugin is now available! Please refer to the <a href="%s" target="_blank">Release Notes</a> section for information about its compatibility and features.',$this->getReleaseVersion(),self::RELEASE_NOTES_URL));
+    }
+
+    /**
+     * Check if a new release is available in Github
+     *
+     * @return bool
+     * @throws FileSystemException
+     * @throws ValidatorException
+     */
+    private function checkIfNewReleaseAvailable():bool
+    {
+        return $this->getReleaseVersion() !== $this->getPluginVersion();
+    }
+
+    /**
+     * Get latest version information of the release from Github
+     *
+     * @return mixed
+     * @throws FileSystemException
+     * @throws ValidatorException
+     */
+    private function getReleaseVersion():mixed
+    {
+        if ($this->session->getTagName() !== null) {
+            return $this->session->getTagName();
+        }
+        $this->curl->addHeader("Content-Type", "application/json");
+        $this->curl->addHeader("User-Agent", 'Github Api Curl');
+        $this->curl->get(self::API_ENDPOINT);
+        $body = $this->curl->getBody();
+        $bodyData = $this->json->unserialize($body);
+
+        return $this->session->setTagName($bodyData ? $bodyData['tag_name'] : $this->getPluginVersion());
+    }
+
+    /**
+     * Get plugin's version number by reading the composer.json
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws \Magento\Framework\Exception\ValidatorException
+     */
+    private function getPluginVersion():string
+    {
+        $path = $this->componentRegistrar->getPath(
+            ComponentRegistrar::MODULE,
+            self::MODULE_FULL_NAME
+        );
+        $directoryRead = $this->readFactory->create($path);
+        $composerJsonData = '';
+        if ($directoryRead->isFile('composer.json')) {
+            $composerJsonData = $directoryRead->readFile('composer.json');
+        }
+        return $composerJsonData ? $this->json->unserialize($composerJsonData)['version'] : '';
+    }
+
+    /**
+     * Retrieve system message severity
+     *
+     * @return int
+     */
+    public function getSeverity():int
+    {
+        return self::SEVERITY_NOTICE;
+    }
+
+}

--- a/Model/Ui/Hpf/ConfigProvider.php
+++ b/Model/Ui/Hpf/ConfigProvider.php
@@ -26,6 +26,7 @@ class ConfigProvider implements ConfigProviderInterface
 {
     const METHOD_CODE = 'tns_hpf';
     const CC_VAULT_CODE = 'tns_hpf_vault';
+    const METHOD_VERIFY = 'order';
 
     /**
      * @var Config
@@ -56,13 +57,16 @@ class ConfigProvider implements ConfigProviderInterface
      */
     public function getConfig()
     {
+    
+        $payment_action = $this->config->getValue('payment_action');
+        $threedsecure_version = ($payment_action == static::METHOD_VERIFY) ? 0 : (int)$this->config->getValue('three_d_secure');
         return [
             'payment' => [
                 self::METHOD_CODE => [
                     'merchant_username' => $this->config->getMerchantId(),
                     'component_url' => $this->config->getComponentUrl(),
                     'debug' => (bool)$this->config->getValue('debug'),
-                    'three_d_secure_version' => (int)$this->config->getValue('three_d_secure'),
+                    'three_d_secure_version' => $threedsecure_version,
                     'ccVaultCode' => static::CC_VAULT_CODE,
                     'check_url' => $this->urlBuilder->getUrl(
                         'tns/threedsecure/check',

--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ Magento 2 Mastercard Payment Gateway Service module supports the following list 
 ## Documentation
 
 The official documentation for this module is available on: [https://mpgs.fingent.wiki/target/magento-2-mastercard-payment-gateway-services/version-compatibility/](https://mpgs.fingent.wiki/target/magento-2-mastercard-payment-gateway-services/version-compatibility/)
+
+## Support
+For customer support: [https://mpgsfgs.atlassian.net/servicedesk/customer/portals](https://mpgsfgs.atlassian.net/servicedesk/customer/portals/)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,46 @@
+# Release documentation
+
+### Pre-requisites
+In order to release a new version of the module, you will need the following:
+
+1. Necessary permissions to the Github repository to create tags and releases.
+2. All the required code is merged to target branch.
+3. Ensure that the module's [CHANGELOG.md](CHANGELOG.md) file has been updated to contain details of the release you are planning to make.
+4. Clone of the Github repository in a local computer (local repo).
+
+You should then follow these steps:
+
+## 1. Merge necessary Pull Requests
+Before creating a release, check that all pull requests are merged into the agreed target branch, usually "master".
+
+## 2. Draft a release in Github
+Create a release by clicking on "Draft a new release".
+
+Enter new release version number to "Choose a tag" box, the same number as in the project's **composer.json** file, for example "1.0.1".
+
+For the Target, choose the "master" branch or a different branch if it was previously agreed.
+
+For Release title, enter something more user friendly, for example "Version 1.0.1"
+
+Leave release description blank for now.
+
+Click on the "Publish release" button.
+
+## 3. Create dist
+In local repo, enter following commands to create a dist zip file, in the example 1.0.1 is used, make sure this is replaced by the correct tag name
+
+```
+git fetch --tags --all
+git archive 1.0.1 -o module-dist.zip
+```
+
+Created file module-dist.zip contains the distributable code for this module.
+
+## 4. Add assets and finalise the release
+In the Github UI, switch to edit the release you created in step 2. The URL will contain something like /edit/1.0.1, for example.
+
+Upload the module-dist.zip into the designated area in the release edit page.
+
+Populate the release description with the information about the version that you can find in the [CHANGELOG.md](CHANGELOG.md) file.
+
+Click on the "Update release" button, and inform the development team that the release has been published.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Official Magento2 Plugin to integrate with MasterCard Payments by Fingent",
   "type": "magento2-module",
   "license": "Apache-2.0",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "authors": [
     {
       "name": "The Fingent Team",

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -54,4 +54,10 @@
             <argument name="config" xsi:type="object">MpgsAchConfig</argument>
         </arguments>
     </virtualType>
-</config>
+    <type name="Magento\Framework\Notification\MessageList">
+        <arguments>
+            <argument name="messages" xsi:type="array">
+                <item name="releaseNotification" xsi:type="string">Mastercard\Mastercard\Model\System\Message\ReleaseNotification</item>
+            </argument>
+        </arguments>
+    </type></config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -279,6 +279,9 @@
                         <source_model>Mastercard\Mastercard\Model\Config\Source\TreeDSecureVersion</source_model>
                         <config_path>payment/tns_hpf/three_d_secure</config_path>
                         <comment>Be sure to Enable 3D-Secure in your MasterCard account</comment>
+                         <depends>
+                            <field id="payment_action" separator="|">authorize|authorize_capture</field>
+                        </depends>   
                     </field>
                     <field id="currency" translate="label" type="select" sortOrder="190" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Accepted Currency</label>
@@ -346,7 +349,7 @@
                 <group id="ach" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Automated Clearing House (ACH)</label>
                     <comment>Automated Clearing House (ACH) only supports USD</comment>
-                    <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enabled</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mpgs_ach/active</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -33,7 +33,7 @@
                 <send_line_items>1</send_line_items>
                 <currency>USD</currency>
 
-                <api_version>73</api_version>
+                <api_version>81</api_version>
                 <api_gateway>api_na</api_gateway>
                 <api_eu>https://eu-gateway.mastercard.com/</api_eu>
                 <api_as>https://ap-gateway.mastercard.com/</api_as>
@@ -78,7 +78,7 @@
                 <send_line_items>1</send_line_items>
                 <currency>USD</currency>
 
-                <api_version>73</api_version>
+                <api_version>81</api_version>
                 <api_gateway>api_na</api_gateway>
                 <api_eu>https://eu-gateway.mastercard.com/</api_eu>
                 <api_as>https://ap-gateway.mastercard.com/</api_as>
@@ -140,7 +140,7 @@
                 <send_line_items>1</send_line_items>
                 <currency>USD</currency>
 
-                <api_version>73</api_version>
+                <api_version>81</api_version>
                 <api_gateway>api_na</api_gateway>
                 <api_eu>https://eu-gateway.mastercard.com/</api_eu>
                 <api_as>https://ap-gateway.mastercard.com/</api_as>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -22,6 +22,7 @@
                 <value id="ap-gateway_mastercard_com" type="host">ap-gateway.mastercard.com</value>
                 <value id="na-gateway_mastercard_com" type="host">na-gateway.mastercard.com</value>
                 <value id="gateway_mastercard_com" type="host">*.gateway.mastercard.com</value>
+                <value id="gateway_spring_citi_com" type="host">*.gateway.spring.citi.com</value>
             </values>
         </policy>
         <policy id="frame-src">


### PR DESCRIPTION
- Module is now compatible with Magento version 2.4.6 p6. 
- Implemented a notification feature to alert the admin whenever a new version is launched on GitHub/Marketplace.
- Hosted Session – The VATO option will only be supported when 3DS is disabled.
- ACH will not support the VATO payment option as it does not allow capturing the amount.