### PR TITLE
Fixed invalid system.xml file, the dependencies should be defined in …

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -159,7 +159,7 @@
                             <config_path>payment/tns_hosted/enable_merchant_info</config_path>
                             <comment>Enable or disable the display of merchant information on the redirected payment page.</comment>
                              <depends>
-                              <field id="form_type" value="1" />
+                              <field id="form_type">1</field>
                              </depends>
                         </field>
                          <field id="name" translate="label" type="text" sortOrder="230" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -169,8 +169,8 @@
                             <config_path>payment/tns_hosted/merchant_name</config_path>
                             <comment>Name of your business (up to 40 characters) to be shown to the payer during the payment interaction.</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                <field id="form_type">1</field>
                             </depends>
                         </field>
 
@@ -181,8 +181,8 @@
                             <config_path>payment/tns_hosted/address_line1</config_path>
                             <comment>The first line of your business address (up to 100 characters) to be shown to the payer during the payment interaction.</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                <field id="form_type">1</field>
                             </depends>
                         </field>
 
@@ -193,8 +193,8 @@
                             <config_path>payment/tns_hosted/address_line2</config_path>
                             <comment>The second line of your business address (up to 100 characters) to be shown to the payer during the payment interaction.</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                <field id="form_type">1</field>
                             </depends>
                         </field>
 
@@ -205,8 +205,8 @@
                             <config_path>payment/tns_hosted/postcode</config_path>
                             <comment>The postal or ZIP code of your business address (up to 100 characters) to be shown to the payer during the payment interaction.</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                 <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                 <field id="form_type">1</field>
                             </depends>
                         </field>
 
@@ -217,8 +217,8 @@
                             <config_path>payment/tns_hosted/country</config_path>
                             <comment>The country or state of your business address (up to 100 characters) to be shown to the payer during the payment interaction.</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                <field id="form_type">1</field>
                             </depends>
                         </field> 
 
@@ -229,8 +229,8 @@
                             <config_path>payment/tns_hosted/email</config_path>
                             <comment>The email address of your business to be shown to the payer during the payment interaction. (e.g. an email address for customer service).</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                <field id="form_type">1</field>
                             </depends>
                         </field>
 
@@ -241,8 +241,8 @@
                             <config_path>payment/tns_hosted/phone</config_path>
                             <comment>The phone number of your business (up to 20 characters) to be shown to the payer during the payment interaction.</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                <field id="form_type">1</field>
                             </depends>
                         </field>
 
@@ -256,8 +256,8 @@
                             <comment>The URL of your business logo (JPEG or PNG) to be shown to the payer during the payment interaction.
                             The logo should be 140x140 pixels, and the URL must be secure (e.g., https://). Size exceeding 140 pixels will be auto resized.</comment>
                             <depends>
-                                <field id="enable_merchant_info" value="1" />
-                                <field id="form_type" value="1" />
+                                <field id="enable_merchant_info">1</field>
+                                <field id="form_type">1</field>
                             </depends>
                         </field>
                     <group id="advanced" translate="label" type="text" sortOrder="270" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
…this way.

The changes introduced in version 2.4.7 with regards to 'Merchant Information' configuration in the `system.xml` file were done incorrectly and these are not valid according to the XSD.

This is hard to reproduce, but I managed to somehow run into this error while executing `bin/magento` locally on my dev machine, it didn't happen all the time:

```
  The XML in file "vendor/fingent/module-mastercard/etc/adminhtml/system.xml" is invalid:
  Element 'field', attribute 'value': The attribute 'value' is not allowed.
  Line: 162
  The xml was:
  157:                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
  158:                            <config_path>payment/tns_hosted/enable_merchant_info</config_path>
  159:                            <comment>Enable or disable the display of merchant information on the redirected payment page.</comment>
  160:                             <depends>
  161:                              <field id="form_type" value="1"/>
  162:                             </depends>
  163:                        </field>
  164:                         <field id="name" translate="label" type="text" sortOrder="230" showInDefault="1" showInWebsite="1" showInStore="0">
  165:                            <label>Merchant Name</label>
  166:                            <validate>validate-alpha-with-spaces</validate>

...
```

This is just a snippet, the full error is much bigger.


An easy way to find all invalid structure in this xml file, is to use the `xmllint` utility if you have it installed:
```
$ xmllint --noout --schema vendor/magento/module-config/etc/system_file.xsd vendor/fingent/module-mastercard/etc/adminhtml/system.xml
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:162: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:172: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:173: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:184: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:185: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:196: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:197: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:208: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:209: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:220: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:221: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:232: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:233: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:244: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:245: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:259: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml:260: Schemas validity error : Element 'field', attribute 'value': The attribute 'value' is not allowed.
vendor/fingent/module-mastercard/etc/adminhtml/system.xml fails to validate
```


This PR fixes this.

@SreedarshA: can you take a look and try to merge and release this fix soon-ish? As this can break some workflows on dev machines. Thanks!